### PR TITLE
refactor(decorator): excise DummyCache and args normalisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = ["polars>=1.32.2"]
 debug = ["pysnooper>=1.2.3"]
 test = ["pytest>=8.4.1"]
 publish = ["pdm>=2.25.6", "pdm-bump>=0.9.12"]
+devex = ["mvdef>=0.9.4"]
 
 [tool.uv]
 default-groups = ["dev", "debug", "test", "publish"]

--- a/src/plcache/_args.py
+++ b/src/plcache/_args.py
@@ -1,0 +1,68 @@
+"""Function signature and argument handling utilities for cache key generation.
+
+This module provides utilities for normalizing function arguments and signatures
+to create consistent cache keys. It handles argument binding, default values,
+and **kwargs sorting to ensure that functionally equivalent function calls
+produce identical cache keys regardless of argument order or style.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def sort_args(sig: inspect.Signature, bound_args: dict):
+    """Sort any variadic kwargs (**kwargs) with signature parameters first.
+
+    Signature parameters are already bound in signature order with defaults), then any
+    remaining **kwargs unpacked alphabetically.
+
+    Args:
+        sig: Function signature to use for ordering.
+        bound_args: Dict of bound named arguments (which may contain unsorted **kwargs).
+
+    Returns:
+        Named args dict in signature order followed by alphabetically sorted **kwargs.
+
+    Example:
+        Here we have two signature args "b" and "a" (in that order). We first sort
+        the signature parameters to ("a", "b") then the **kwargs to ("c", "d").
+
+        >>> def f(a, b, **kw): pass
+        >>> sig = inspect.signature(f)
+        >>> args = tuple()
+        >>> kwargs = dict(b=2, a=1, d=4, c=3)
+        >>> bound = sig.bind(*args, **kwargs)
+        >>> bound_args = bound.arguments  # {'a': 1, 'b': 2, 'kw': {'d': 4, 'c': 3}}
+        >>> sort_args(sig, bound_args)
+        {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+    """
+
+    def not_var_keyword(param_name: str):
+        """Check if parameter is not **kwargs (already sorted)."""
+        return sig.parameters[param_name].kind != inspect.Parameter.VAR_KEYWORD
+
+    # Ordered names of parameters in the signature
+    bound_sig_params = list(filter(not_var_keyword, sig.parameters))
+    # There can be only one variadic **kwargs parameter
+    var_kw_params = set(bound_args) - set(bound_sig_params)
+    # Unpacked **kwargs dict of key: value that are not bound in the function signature
+    unpacked_kwargs = bound_args[var_kw_params.pop()] if any(var_kw_params) else {}
+    # Flatten out the **kwargs into the same dict as the bound signature params
+    return {
+        **{k: bound_args[k] for k in bound_sig_params},
+        **{k: unpacked_kwargs[k] for k in sorted(unpacked_kwargs)},
+    }
+
+
+def normalise_args(func, args, kwargs, sort: bool = True):
+    """Normalise all parameters to signature order, **kwargs sorted and unpacked last.
+
+    If `sort` is passed as True, sort the **kwargs (to avoid the same **kwargs in
+    different order causing a cache miss, as the order of **kwargs rarely matters).
+    """
+    sig = inspect.signature(func)
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()  # Add missing defaults
+    bound_args = bound.arguments  # k:v dict of all signature params
+    return sort_args(sig, bound_args) if sort else bound_args

--- a/src/plcache/_dummy.py
+++ b/src/plcache/_dummy.py
@@ -1,0 +1,28 @@
+"""Dummy cache implementation that provides a no-op decorator interface.
+
+This module contains a placeholder cache that doesn't actually cache anything,
+used as a default before the real cache is initialized or when caching is disabled.
+"""
+
+from __future__ import annotations
+
+
+class _DummyCache:
+    """A dummy cache that does nothing - just executes functions normally."""
+
+    cache_dir = None
+
+    def cache_polars(self, **kwargs):
+        """Return a no-op decorator that doesn't cache anything.
+
+        Args:
+            **kwargs: Ignored keyword arguments for compatibility.
+
+        Returns:
+            A decorator that returns the original function unchanged.
+        """
+
+        def decorator(func):
+            return func  # Just return the original function unchanged
+
+        return decorator

--- a/src/plcache/decorator.py
+++ b/src/plcache/decorator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import functools
 import hashlib
-import inspect
 import os
 import tempfile
 import urllib.parse
@@ -14,6 +13,7 @@ from typing import TYPE_CHECKING, Any, overload
 import diskcache
 import polars as pl
 
+from ._args import normalise_args
 from ._debugging import snoop
 from ._dummy import _DummyCache
 from ._parse_sizes import _parse_size
@@ -39,63 +39,6 @@ def _DEFAULT_CACHE_IDENT(func: DecoratedFn, bound_args: dict[str, Any]) -> str:
         str: Conjoined function module, qualname, and positional/named arguments.
     """
     return f"{func.__module__}.{func.__qualname__}({bound_args})"
-
-
-def sort_args(sig: inspect.Signature, bound_args: dict):
-    """Sort any variadic kwargs (**kwargs) with signature parameters first.
-
-    Signature parameters are already bound in signature order with defaults), then any
-    remaining **kwargs unpacked alphabetically.
-
-    Args:
-        sig: Function signature to use for ordering.
-        bound_args: Dict of bound named arguments (which may contain unsorted **kwargs).
-
-    Returns:
-        Named args dict in signature order followed by alphabetically sorted **kwargs.
-
-    Example:
-        Here we have two signature args "b" and "a" (in that order). We first sort
-        the signature parameters to ("a", "b") then the **kwargs to ("c", "d").
-
-        >>> def f(a, b, **kw): pass
-        >>> sig = inspect.signature(f)
-        >>> args = tuple()
-        >>> kwargs = dict(b=2, a=1, d=4, c=3)
-        >>> bound = sig.bind(*args, **kwargs)
-        >>> bound_args = bound.arguments  # {'a': 1, 'b': 2, 'kw': {'d': 4, 'c': 3}}
-        >>> sort_args(sig, bound_args)
-        {'a': 1, 'b': 2, 'c': 3, 'd': 4}
-    """
-
-    def not_var_keyword(param_name: str):
-        """Check if parameter is not **kwargs (already sorted)."""
-        return sig.parameters[param_name].kind != inspect.Parameter.VAR_KEYWORD
-
-    # Ordered names of parameters in the signature
-    bound_sig_params = list(filter(not_var_keyword, sig.parameters))
-    # There can be only one variadic **kwargs parameter
-    var_kw_params = set(bound_args) - set(bound_sig_params)
-    # Unpacked **kwargs dict of key: value that are not bound in the function signature
-    unpacked_kwargs = bound_args[var_kw_params.pop()] if any(var_kw_params) else {}
-    # Flatten out the **kwargs into the same dict as the bound signature params
-    return {
-        **{k: bound_args[k] for k in bound_sig_params},
-        **{k: unpacked_kwargs[k] for k in sorted(unpacked_kwargs)},
-    }
-
-
-def normalise_args(func, args, kwargs, sort: bool = True):
-    """Normalise all parameters to signature order, **kwargs sorted and unpacked last.
-
-    If `sort` is passed as True, sort the **kwargs (to avoid the same **kwargs in
-    different order causing a cache miss, as the order of **kwargs rarely matters).
-    """
-    sig = inspect.signature(func)
-    bound = sig.bind(*args, **kwargs)
-    bound.apply_defaults()  # Add missing defaults
-    bound_args = bound.arguments  # k:v dict of all signature params
-    return sort_args(sig, bound_args) if sort else bound_args
 
 
 class PolarsCache:

--- a/src/plcache/decorator.py
+++ b/src/plcache/decorator.py
@@ -15,12 +15,17 @@ import diskcache
 import polars as pl
 
 from ._debugging import snoop
+from ._dummy import _DummyCache
 from ._parse_sizes import _parse_size
 
 if TYPE_CHECKING:
     from .types import CacheKeyCallback, DecoratedFn, EntryDirCallback, FilenameCallback
 
 _DEFAULT_SYMLINK_NAME = "output.parquet"
+
+
+# Convenience function for creating a global cache instance. Initialise with dummy cache
+_global_cache: PolarsCache | _DummyCache = _DummyCache()
 
 
 def _DEFAULT_CACHE_IDENT(func: DecoratedFn, bound_args: dict[str, Any]) -> str:
@@ -452,31 +457,6 @@ class PolarsCache:
 
             shutil.rmtree(self.readable_dir, ignore_errors=True)
             self.readable_dir.mkdir(exist_ok=True)
-
-
-class _DummyCache:
-    """A dummy cache that does nothing - just executes functions normally."""
-
-    cache_dir = None
-
-    def cache_polars(self, **kwargs):
-        """Return a no-op decorator that doesn't cache anything.
-
-        Args:
-            **kwargs: Ignored keyword arguments for compatibility.
-
-        Returns:
-            A decorator that returns the original function unchanged.
-        """
-
-        def decorator(func):
-            return func  # Just return the original function unchanged
-
-        return decorator
-
-
-# Convenience function for creating a global cache instance. Initialise with dummy cache
-_global_cache: PolarsCache | _DummyCache = _DummyCache()
 
 
 @snoop()

--- a/tests/custom_callbacks_test.py
+++ b/tests/custom_callbacks_test.py
@@ -286,7 +286,7 @@ def test_sort_args_function():
     """Test the sort_args utility function directly."""
     import inspect
 
-    from plcache.decorator import sort_args
+    from plcache._args import sort_args
 
     def example_func(b: int, a: str, **kwargs):
         pass

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,33 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/0f/861e168fc813c56a78b35f3c30d91c6757d1fd185af1110f1aec784b35d0/argcomplete-3.6.2.tar.gz", hash = "sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf", size = 73403, upload-time = "2025-04-03T04:57:03.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/da/e42d7a9d8dd33fa775f467e4028a47936da2f01e4b0e561f9ba0d74cb0ca/argcomplete-3.6.2-py3-none-any.whl", hash = "sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591", size = 43708, upload-time = "2025-04-03T04:57:01.591Z" },
+]
+
+[[package]]
+name = "astor"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/21/75b771132fee241dfe601d39ade629548a9626d1d39f333fde31bc46febe/astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e", size = 35090, upload-time = "2019-12-10T01:50:35.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/88/97eef84f48fa04fbd6750e62dcceafba6c63c81b7ac1420856c8dcc0a3f9/astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5", size = 27488, upload-time = "2019-12-10T01:50:33.628Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978, upload-time = "2024-11-30T04:30:14.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918, upload-time = "2024-11-30T04:30:10.946Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -83,6 +110,20 @@ wheels = [
 ]
 
 [[package]]
+name = "defopt"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "sphinxcontrib-napoleon" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/53/89e5eaa8e775cef5b66254365f51c389ca167b0fa96713b722824708b720/defopt-7.0.0.tar.gz", hash = "sha256:d7ac98810005880717e1df62527fd35dfe083f551b6d4fb5da0b25f608e8ef4c", size = 44527, upload-time = "2025-06-15T21:42:35.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/be/03e94203daf8653bb402936820ac762064b4ef6079daab47581506c187c7/defopt-7.0.0-py3-none-any.whl", hash = "sha256:88b6747561d803e3fc020b9080fd0aa6a300927f64167c76d95544495f1a8307", size = 17795, upload-time = "2025-06-19T06:48:48.835Z" },
+]
+
+[[package]]
 name = "dep-logic"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -110,6 +151,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/86/5b41c32ecedcfdb4c77b28b6cb14234f252075f8cdb254531727a35547dd/docutils-0.22.tar.gz", hash = "sha256:ba9d57750e92331ebe7c08a1bbf7a7f8143b86c476acd51528b042216a6aad0f", size = 2277984, upload-time = "2025-07-29T15:20:31.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/57/8db39bc5f98f042e0153b1de9fb88e1a409a33cda4dd7f723c2ed71e01f6/docutils-0.22-py3-none-any.whl", hash = "sha256:4ed966a0e96a0477d852f7af31bdcb3adc049fbb35ccba358c2ea8a03287615e", size = 630709, upload-time = "2025-07-29T15:20:28.335Z" },
 ]
 
 [[package]]
@@ -249,6 +299,22 @@ wheels = [
 ]
 
 [[package]]
+name = "mvdef"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "astor" },
+    { name = "asttokens" },
+    { name = "defopt" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/2a/fd7d63bdd6e375e6d42dfba5717dbd167edcea69085a0e3a91b169f0cf3a/mvdef-0.9.4.tar.gz", hash = "sha256:1f7ed65276eecb6a448aace12932dfd74b2bd72e1c95f03a30a529fac985d25f", size = 411231, upload-time = "2024-03-03T16:44:30.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/d9/98817d1d0eba6ff97bba0c1d035dcb3cd69b25307d3adae6d1249c1ca131/mvdef-0.9.4-py3-none-any.whl", hash = "sha256:e17fe8ad1a182da281585e62577b127037d59c22757134169b52011cd73df048", size = 410141, upload-time = "2024-03-03T16:44:28.239Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +412,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pockets"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/8e/0601097cfcce2e8c2297db5080e9719f549c2bd4b94420ddc8d3f848bbca/pockets-0.9.1.tar.gz", hash = "sha256:9320f1a3c6f7a9133fe3b571f283bcf3353cd70249025ae8d618e40e9f7e92b3", size = 24993, upload-time = "2019-11-02T14:46:19.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/2f/a4583c70fbd8cd04910e2884bcc2bdd670e884061f7b4d70bc13e632a993/pockets-0.9.1-py2.py3-none-any.whl", hash = "sha256:68597934193c08a08eb2bf6a1d85593f627c22f9b065cc727a4f03f669d96d86", size = 26263, upload-time = "2019-11-02T14:46:17.814Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.32.2"
 source = { registry = "https://pypi.org/simple" }
@@ -375,6 +453,9 @@ debug = [
 dev = [
     { name = "polars" },
 ]
+devex = [
+    { name = "mvdef" },
+]
 publish = [
     { name = "pdm" },
     { name = "pdm-bump" },
@@ -392,11 +473,21 @@ requires-dist = [
 [package.metadata.requires-dev]
 debug = [{ name = "pysnooper", specifier = ">=1.2.3" }]
 dev = [{ name = "polars", specifier = ">=1.32.2" }]
+devex = [{ name = "mvdef", specifier = ">=0.9.4" }]
 publish = [
     { name = "pdm", specifier = ">=2.25.6" },
     { name = "pdm-bump", specifier = ">=0.9.12" },
 ]
 test = [{ name = "pytest", specifier = ">=8.4.1" }]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
 
 [[package]]
 name = "pygments"
@@ -509,6 +600,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -524,6 +624,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-napoleon"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pockets" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/eb/ad89500f4cee83187596e07f43ad561f293e8e6e96996005c3319653b89f/sphinxcontrib-napoleon-0.7.tar.gz", hash = "sha256:407382beed396e9f2d7f3043fad6afda95719204a1e1a231ac865f40abcbfcf8", size = 21232, upload-time = "2018-09-23T14:16:47.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/f2/6b7627dfe7b4e418e295e254bb15c3a6455f11f8c0ad0d43113f678049c3/sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl", hash = "sha256:711e41a3974bdf110a484aec4c1a556799eb0b3f3b897521a018ad7e2db13fef", size = 17151, upload-time = "2018-09-23T14:16:45.548Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Initial shrinkage
- Dummy cache excised from decorator module (and its creation is now not "hidden" in the midst of code)
- Args normalisation excised from decorator module and imported